### PR TITLE
Adding Kaggle API credentials back in

### DIFF
--- a/kaggle/kaggle.json
+++ b/kaggle/kaggle.json
@@ -1,0 +1,1 @@
+{"username":"jsimpson2","key":"ec69a78380d15ef697ad53bbc1739b7a"}


### PR DESCRIPTION
- Think these somehow got deleted in the cleanup - just need them in the file to download the landscape pictures dataset.
- Should just be the API key to my Kaggle account :) 